### PR TITLE
Fix: handle ConnectionRefused exc when impossible to connect to router, update minimal python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="genai-protocol",
-    version="1.0.5",
+    version="1.0.6",
     description="GenAI Python project for agents connector library that integrates with GenAI infrastructure",
-    long_description=open('README.md', encoding='utf-8').read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Yaroslav Oliinyk, Valentyn Slivko, Ivan Kuzlo",
     author_email="yaroslav.oliinyk@chisw.com, valentyn.slivko@chisw.com, ivan.kuzlo@chisw.com",
@@ -35,10 +35,11 @@ setup(
         "dev": ["twine>=6.1.0"],
     },
     classifiers=[
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.10",
 )

--- a/src/genai_session/session.py
+++ b/src/genai_session/session.py
@@ -285,9 +285,9 @@ class GenAISession:
                 listener_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await listener_task
-        except websockets.exceptions.ConnectionClosedError:
+        except (websockets.exceptions.ConnectionClosedError, ConnectionRefusedError):
             raise RouterInaccessibleException("Router service is not accessible. Please make sure it is running and accepting websocket messages")  # noqa: E501
-    
+
     def _handle_task_result(self, task: asyncio.Task):
         try:
             task.result()


### PR DESCRIPTION
Added additional exception handling for consistency when router is inaccessible while trying to initially connect to it from other infrastructure objects like so
<img width="940" alt="image" src="https://github.com/user-attachments/assets/3f6d02fb-bec7-4c73-9d58-396a67d54748" />

Before these changes, `ConnectionRefusedError` would've been raised if router is not accessible